### PR TITLE
Adding default uri to the database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -7,7 +7,7 @@ load_dotenv()
 # Load environment variables (ensure dotenv is loaded if necessary)
 username = os.getenv("MONGODB_USERNAME")
 password = os.getenv("MONGODB_PASSWORD")
-uri = os.getenv("MONGODB_URI")
+uri = os.getenv("MONGODB_URI", "cluster0.flk7i.mongodb.net/")
 
 # Initialize MongoDB client and database
 client = MongoClient(f"mongodb+srv://{username}:{password}@{uri}?retryWrites=true&w=majority&appName=Cluster0")


### PR DESCRIPTION
I noticed that MONGODB_URI is missing from the pipeline. It's probably missing from GitHub Secrets as well. I will fix it by adding default value to the variable. You can modify the pipeline if you wish to do so.